### PR TITLE
Simplify import for boxwhisker_plotter and scatter_plotter.

### DIFF
--- a/readyplot/__init__.py
+++ b/readyplot/__init__.py
@@ -8,5 +8,29 @@ functions: custom_plotter (full plotting + formating) and prism_reskin (only
 reformats given figures).
 @author: paveyboys
 """
+# readyplot/__init__.py
+
 from .boxwhisker_plotter import BoxWhiskerPlotter
 from .scatter_plotter import ScatterPlotter
+
+def boxwhisker_plotter(DFs=None, x=None, y=None, z=None, xlab='Group', ylab='ylab', zlab='zlab',
+                       folder_name='OUTPUT_FIGURES', colors=['c', 'm', 'g'], low_y_cap0=True,
+                       handles_in_legend=3, fig_width=7, fig_height=5, box_width=0.9,
+                       custom_y_label=None):
+    return BoxWhiskerPlotter(DFs=DFs, x=x, y=y, z=z, xlab=xlab, ylab=ylab, zlab=zlab,
+                             folder_name=folder_name, colors=colors, low_y_cap0=low_y_cap0,
+                             handles_in_legend=handles_in_legend, fig_width=fig_width,
+                             fig_height=fig_height, box_width=box_width,
+                             custom_y_label=custom_y_label)
+
+def scatter_plotter(DFs=None, x=None, y=None, z=None, xlab='Group', ylab='ylab', zlab='zlab',
+                    folder_name='OUTPUT_FIGURES', colors=['c', 'm', 'g'], low_y_cap0=True,
+                    handles_in_legend=3, fig_width=7, fig_height=5, box_width=0.9,
+                    custom_y_label=None):
+    return ScatterPlotter(DFs=DFs, x=x, y=y, z=z, xlab=xlab, ylab=ylab, zlab=zlab,
+                          folder_name=folder_name, colors=colors, low_y_cap0=low_y_cap0,
+                          handles_in_legend=handles_in_legend, fig_width=fig_width,
+                          fig_height=fig_height, box_width=box_width,
+                          custom_y_label=custom_y_label)
+
+__all__ = ['boxwhisker_plotter', 'scatter_plotter', 'BoxWhiskerPlotter', 'ScatterPlotter']


### PR DESCRIPTION
Simplified the calling of `readyplot` by modifying `___init___.py`. Now functions can be called as follows:
``` Python
import readyplot

box_plotter = readyplot.boxwhisker_plotter(x=x, y=y, xlab='Group', colors='c')
scatter_plotter = readyplot.scatter_plotter(x=x, y=y, xlab='Group', colors='c')
```

Instead of (OLD):
```Python
import readyplot

box_plotter = readyplot.boxwhisker_plotter.BoxWhiskerPlotter(x=x, y=y, xlab='Group', colors='c')
```
Note the double classes after ready plot. Also in the future, the names immediately after readyplot (ie boxwhisker_plotter ) should most likely be simplified to boxwhisker and scatter for example. This can be simply done by changing the name after `def` (ie `def scatter_plotter` -> `def scatter`)
Best,
Alexander